### PR TITLE
Load env variables from .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # binance-telegram-trading-bot
 Trading bot for Binance integrated with Telegram, focusing on informative and interactive messages and detailed logging.
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Edit `.env` and provide your Binance API keys and Telegram bot token.
+
+The bot loads this file automatically on startup so your environment variables are available.

--- a/binance_client.py
+++ b/binance_client.py
@@ -1,4 +1,5 @@
 import os
+import env_loader
 from binance import AsyncClient
 
 async def get_binance_client():

--- a/env_loader.py
+++ b/env_loader.py
@@ -1,0 +1,3 @@
+from dotenv import load_dotenv
+
+load_dotenv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 pandas-ta
 schedule
 aiohttp
+python-dotenv

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,4 +1,5 @@
 import os
+import env_loader
 import asyncio
 import logging
 


### PR DESCRIPTION
## Summary
- allow bot to load environment variables from a `.env` file
- hook environment loader in `binance_client` and `telegram_bot`
- document basic setup in `README`
- add `python-dotenv` requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68842db26e34832990d6c5b77e748e1e