### PR TITLE
Add Telegram command to adjust strategy weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Trading bot for Binance integrated with Telegram, focusing on informative and in
 2. Edit `.env` and provide your Binance API keys and Telegram bot token.
 
 The bot loads this file automatically on startup so your environment variables are available.
+
+## Strategy Weights
+
+You can control how much capital each strategy uses by setting weights from Telegram. The weights of all strategies must sum to `1`.
+
+Use `/weights` to view the current weights and `/setweights <dca> <grid> <scalping> <trend> <sentiment>` to update them. For example:
+
+```
+/setweights 0.2 0.2 0.2 0.2 0.2
+```

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -3,14 +3,21 @@ import env_loader
 import asyncio
 import logging
 
-from trading_tasks import dca_loop, grid_loop, scalping_loop, trend_loop, sentiment_loop
+from trading_tasks import (
+    dca_loop,
+    grid_loop,
+    scalping_loop,
+    trend_loop,
+    sentiment_loop,
+    CONFIG,
+)
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 
 logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level=logging.INFO
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
 )
 logger = logging.getLogger(__name__)
+
 
 async def start_command(update, context):
     await update.message.reply_text(
@@ -19,19 +26,59 @@ async def start_command(update, context):
         "Use the /help command to see all available commands."
     )
 
+
 async def status_command(update, context):
     await update.message.reply_text(
         "The strategies are running in the background. Check the logs for more details."
     )
+
 
 async def help_command(update, context):
     await update.message.reply_text(
         "Available commands:\n"
         "/start – start chatting with the bot\n"
         "/status – check the current status of the strategies\n"
-        "/help – display this command list"
-
+        "/help – display this command list\n"
+        "/weights – show current strategy weights\n"
+        "/setweights – set new strategy weights"
     )
+
+
+async def weights_command(update, context):
+    weights = CONFIG.get("weights", {})
+    message = "Current strategy weights:\n"
+    for name, value in weights.items():
+        message += f"{name}: {value:.2f}\n"
+    await update.message.reply_text(message)
+
+
+async def setweights_command(update, context):
+    if len(context.args) != 5:
+        await update.message.reply_text(
+            "Usage: /setweights <dca> <grid> <scalping> <trend> <sentiment>"
+        )
+        return
+    try:
+        dca_w, grid_w, scalping_w, trend_w, sentiment_w = map(float, context.args)
+    except ValueError:
+        await update.message.reply_text("All weights must be numbers")
+        return
+    total = dca_w + grid_w + scalping_w + trend_w + sentiment_w
+    if abs(total - 1.0) > 1e-6:
+        await update.message.reply_text("Total weight must equal 1")
+        return
+
+    CONFIG["weights"].update(
+        {
+            "dca": dca_w,
+            "grid": grid_w,
+            "scalping": scalping_w,
+            "trend": trend_w,
+            "sentiment": sentiment_w,
+        }
+    )
+    await update.message.reply_text("Weights updated")
+
 
 async def telegram_bot():
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
@@ -44,9 +91,12 @@ async def telegram_bot():
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("status", status_command))
     application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(CommandHandler("weights", weights_command))
+    application.add_handler(CommandHandler("setweights", setweights_command))
 
     logger.info("Starting Telegram bot polling")
     await asyncio.to_thread(application.run_polling)
+
 
 async def trading_tasks_runner():
     tasks = [
@@ -58,11 +108,13 @@ async def trading_tasks_runner():
     ]
     await asyncio.gather(*tasks)
 
+
 async def main():
     await asyncio.gather(
         trading_tasks_runner(),
         telegram_bot(),
     )
+
 
 if __name__ == "__main__":
     try:

--- a/trading_tasks.py
+++ b/trading_tasks.py
@@ -4,7 +4,9 @@ import logging
 from strategies import dca, grid, scalping, trend_following, sentiment
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Bot configuration
@@ -21,7 +23,15 @@ CONFIG = {
     "scalping_interval_seconds": 60,
     "trend_interval_minutes": 5,
     "sentiment_interval_minutes": 10,
+    "weights": {
+        "dca": 0.2,
+        "grid": 0.2,
+        "scalping": 0.2,
+        "trend": 0.2,
+        "sentiment": 0.2,
+    },
 }
+
 
 async def dca_loop():
     """
@@ -29,12 +39,15 @@ async def dca_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        amount = CONFIG["dca_amount"]
+        amount = CONFIG["dca_amount"] * CONFIG["weights"]["dca"]
         interval = CONFIG["dca_interval_minutes"]
         # call the DCA strategy implementation
-        await dca.execute(client=None, symbol=symbol, amount=amount, interval_minutes=interval)
+        await dca.execute(
+            client=None, symbol=symbol, amount=amount, interval_minutes=interval
+        )
         # wait until the next DCA trade
         await asyncio.sleep(interval * 60)
+
 
 async def grid_loop():
     """
@@ -45,7 +58,7 @@ async def grid_loop():
         lower = CONFIG["grid"]["lower"]
         upper = CONFIG["grid"]["upper"]
         levels = CONFIG["grid"]["levels"]
-        amount = CONFIG["dca_amount"]
+        amount = CONFIG["dca_amount"] * CONFIG["weights"]["grid"]
         # call the grid strategy implementation
         await grid.execute(
             client=None,
@@ -57,13 +70,14 @@ async def grid_loop():
         )
         await asyncio.sleep(CONFIG["grid_interval_minutes"] * 60)
 
+
 async def scalping_loop():
     """
     Run a high-frequency scalping strategy using short-term indicators.
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = CONFIG["dca_amount"]
+        quantity = CONFIG["dca_amount"] * CONFIG["weights"]["scalping"]
         indicators = {"rsi_period": 14, "ema_fast": 7, "ema_slow": 25}
         # call the scalping strategy implementation
         await scalping.execute(
@@ -74,13 +88,14 @@ async def scalping_loop():
         )
         await asyncio.sleep(CONFIG["scalping_interval_seconds"])
 
+
 async def trend_loop():
     """
     Run a trend-following strategy using momentum indicators.
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = CONFIG["dca_amount"]
+        quantity = CONFIG["dca_amount"] * CONFIG["weights"]["trend"]
 
         # call the trend following strategy implementation
         await trend_following.execute(
@@ -91,17 +106,26 @@ async def trend_loop():
         )
         await asyncio.sleep(CONFIG["trend_interval_minutes"] * 60)
 
+
 async def sentiment_loop():
     """
     Run a sentiment-based strategy that reacts to news or social sentiment.
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = CONFIG["dca_amount"]
-        sentiment_score = 0.0  # placeholder sentiment score; integrate actual sentiment analysis here
+        quantity = CONFIG["dca_amount"] * CONFIG["weights"]["sentiment"]
+        sentiment_score = (
+            0.0  # placeholder sentiment score; integrate actual sentiment analysis here
+        )
         # call the sentiment strategy implementation
-        await sentiment.execute(client=None, symbol=symbol, sentiment_score=sentiment_score, quantity=quantity)
+        await sentiment.execute(
+            client=None,
+            symbol=symbol,
+            sentiment_score=sentiment_score,
+            quantity=quantity,
+        )
         await asyncio.sleep(CONFIG["sentiment_interval_minutes"] * 60)
+
 
 async def main():
     """
@@ -115,6 +139,7 @@ async def main():
         asyncio.create_task(sentiment_loop()),
     ]
     await asyncio.gather(*tasks)
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add strategy weight configuration and apply in loops
- expose `/weights` and `/setweights` commands in Telegram bot
- document weight commands in README

## Testing
- `black trading_tasks.py telegram_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68843312ea488329b3f68fe29c245e7d