### PR TITLE
Improve /setweights help message

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -40,7 +40,9 @@ async def help_command(update, context):
         "/status – check the current status of the strategies\n"
         "/help – display this command list\n"
         "/weights – show current strategy weights\n"
-        "/setweights – set new strategy weights"
+        "/setweights – set new strategy weights\n"
+        "Usage: /setweights <dca> <grid> <scalping> <trend> <sentiment>\n"
+        "The weights must add up to 1"
     )
 
 


### PR DESCRIPTION
## Summary
- document usage of `/setweights` in the help command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884348bd77083299d33852255c2144c