### PR TITLE
Add risk level control via Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ Use `/weights` to view the current weights and `/setweights <dca> <grid> <scalpi
 /setweights 0.2 0.2 0.2 0.2 0.2
 ```
 
+## Risk Level
+
+You can adjust how aggressively the bot trades by setting a risk level between `0.0` and `1.0`.
+The risk level acts as a multiplier on all trade sizes. Use `/risk` to see the
+current level and `/setrisk <level>` to change it. For example, to trade at half
+your usual size:
+
+```
+/setrisk 0.5
+```
+
+Setting the risk level to `0` effectively pauses trading, while `1` leaves trade
+sizes unchanged.
+
 ## Running the Bot
 
 Install the required packages from `requirements.txt` and then start the bot:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -42,7 +42,9 @@ async def help_command(update, context):
         "/weights – show current strategy weights\n"
         "/setweights – set new strategy weights\n"
         "Usage: /setweights <dca> <grid> <scalping> <trend> <sentiment>\n"
-        "The weights must add up to 1"
+        "The weights must add up to 1\n"
+        "/risk – show current risk level\n"
+        "/setrisk – set a new risk level (0.0-1.0)"
     )
 
 
@@ -82,6 +84,27 @@ async def setweights_command(update, context):
     await update.message.reply_text("Weights updated")
 
 
+async def risk_command(update, context):
+    risk = CONFIG.get("risk_level", 1.0)
+    await update.message.reply_text(f"Current risk level: {risk:.2f}")
+
+
+async def setrisk_command(update, context):
+    if len(context.args) != 1:
+        await update.message.reply_text("Usage: /setrisk <level> (0.0-1.0)")
+        return
+    try:
+        level = float(context.args[0])
+    except ValueError:
+        await update.message.reply_text("Risk level must be a number")
+        return
+    if level < 0 or level > 1:
+        await update.message.reply_text("Risk level must be between 0.0 and 1.0")
+        return
+    CONFIG["risk_level"] = level
+    await update.message.reply_text(f"Risk level set to {level:.2f}")
+
+
 def main() -> None:
     """Start the Telegram bot and trading tasks."""
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
@@ -96,6 +119,8 @@ def main() -> None:
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("weights", weights_command))
     application.add_handler(CommandHandler("setweights", setweights_command))
+    application.add_handler(CommandHandler("risk", risk_command))
+    application.add_handler(CommandHandler("setrisk", setrisk_command))
 
     loop = asyncio.get_event_loop()
     loop.create_task(dca_loop())

--- a/trading_tasks.py
+++ b/trading_tasks.py
@@ -30,6 +30,7 @@ CONFIG = {
         "trend": 0.2,
         "sentiment": 0.2,
     },
+    "risk_level": 1.0,
 }
 
 
@@ -39,7 +40,11 @@ async def dca_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        amount = CONFIG["dca_amount"] * CONFIG["weights"]["dca"]
+        amount = (
+            CONFIG["dca_amount"]
+            * CONFIG["weights"]["dca"]
+            * CONFIG.get("risk_level", 1.0)
+        )
         interval = CONFIG["dca_interval_minutes"]
         # call the DCA strategy implementation
         await dca.execute(
@@ -58,7 +63,11 @@ async def grid_loop():
         lower = CONFIG["grid"]["lower"]
         upper = CONFIG["grid"]["upper"]
         levels = CONFIG["grid"]["levels"]
-        amount = CONFIG["dca_amount"] * CONFIG["weights"]["grid"]
+        amount = (
+            CONFIG["dca_amount"]
+            * CONFIG["weights"]["grid"]
+            * CONFIG.get("risk_level", 1.0)
+        )
         # call the grid strategy implementation
         await grid.execute(
             client=None,
@@ -77,7 +86,11 @@ async def scalping_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = CONFIG["dca_amount"] * CONFIG["weights"]["scalping"]
+        quantity = (
+            CONFIG["dca_amount"]
+            * CONFIG["weights"]["scalping"]
+            * CONFIG.get("risk_level", 1.0)
+        )
         indicators = {"rsi_period": 14, "ema_fast": 7, "ema_slow": 25}
         # call the scalping strategy implementation
         await scalping.execute(
@@ -95,7 +108,11 @@ async def trend_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = CONFIG["dca_amount"] * CONFIG["weights"]["trend"]
+        quantity = (
+            CONFIG["dca_amount"]
+            * CONFIG["weights"]["trend"]
+            * CONFIG.get("risk_level", 1.0)
+        )
 
         # call the trend following strategy implementation
         await trend_following.execute(
@@ -113,7 +130,11 @@ async def sentiment_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = CONFIG["dca_amount"] * CONFIG["weights"]["sentiment"]
+        quantity = (
+            CONFIG["dca_amount"]
+            * CONFIG["weights"]["sentiment"]
+            * CONFIG.get("risk_level", 1.0)
+        )
         sentiment_score = (
             0.0  # placeholder sentiment score; integrate actual sentiment analysis here
         )


### PR DESCRIPTION
## Summary
- add `risk_level` configuration option
- scale strategy sizes based on current risk level
- expose `/risk` and `/setrisk` commands to Telegram
- document risk command usage in README

## Testing
- `python -m py_compile telegram_bot.py trading_tasks.py strategies/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68843a169f4c8329b8668e231cad9599