### PR TITLE
Add portfolio command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ Install the required packages from `requirements.txt` and then start the bot:
 ```
 python telegram_bot.py
 ```
+
+## Portfolio Command
+
+Use `/portfolio` in Telegram to view a detailed summary of your Binance account.
+The bot reports the balance of each asset, the average purchase price based on
+your trade history, the current market price and the resulting profit or loss.


### PR DESCRIPTION
## Summary
- add portfolio command to show detailed account info
- list portfolio command in help
- document portfolio command in README

## Testing
- `python -m py_compile *.py strategies/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68843c16b88c83298e071ddafbd28ce1