### PR TITLE
Add dummy trading mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,8 @@ TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 BINANCE_API_KEY=your_binance_api_key_here
 BINANCE_API_SECRET=your_binance_api_secret_here
 
-# Whether to use Binance testnet (demo) or live trading
-# Set to "true" to use testnet, "false" for live trading
-TESTNET=true
+# Set to "true" to use a local simulated account instead of real Binance
+DUMMY_ACCOUNT=false
 
 # Default trading parameters
 SYMBOLS=BTCUSDT,ETHUSDT

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Trading bot for Binance integrated with Telegram, focusing on informative and in
 ## Setup
 
 1. Copy `.env.example` to `.env`.
-2. Edit `.env` and provide your Binance API keys and Telegram bot token.
+2. Edit `.env` and provide your Telegram bot token. If you want to trade on
+   Binance, fill in your API keys. To run the bot without real API access,
+   set `DUMMY_ACCOUNT=true` and the bot will simulate a balance starting at
+   1000 USDT.
 
 The bot loads this file automatically on startup so your environment variables are available.
 

--- a/binance_client.py
+++ b/binance_client.py
@@ -1,21 +1,27 @@
 import os
 import env_loader
 from binance import AsyncClient
+from dummy_client import DummyClient
 
 async def get_binance_client():
     """
-    Create and return an AsyncClient for Binance.
+    Create and return a client for Binance.
 
-    Uses API credentials from environment variables BINANCE_API_KEY and BINANCE_API_SECRET.
-    If the environment variable TESTNET is set to a truthy value (e.g. "true", "1", "yes"),
-    the client will connect to the Binance Spot testnet for demo trading; otherwise,
-    it connects to the live trading environment.
+    By default a local simulation is used when the environment variable
+    ``DUMMY_ACCOUNT`` is set to a truthy value. The simulated account
+    starts with 1000 USDT and charges a 0.1%% fee on each trade.
+    Otherwise a real ``AsyncClient`` is returned using the provided
+    API credentials. Testnet mode is disabled.
     """
+    if os.getenv("DUMMY_ACCOUNT", "false").lower() in ("1", "true", "yes"):
+        return DummyClient()
+
     api_key = os.getenv("BINANCE_API_KEY")
     api_secret = os.getenv("BINANCE_API_SECRET")
     if not api_key or not api_secret:
-        raise RuntimeError("BINANCE_API_KEY or BINANCE_API_SECRET environment variables are not set")
+        raise RuntimeError(
+            "BINANCE_API_KEY or BINANCE_API_SECRET environment variables are not set"
+        )
 
-    testnet = os.getenv("TESTNET", "false").lower() in ("1", "true", "yes")
-    client = await AsyncClient.create(api_key, api_secret, testnet=testnet)
+    client = await AsyncClient.create(api_key, api_secret, testnet=False)
     return client

--- a/dummy_client.py
+++ b/dummy_client.py
@@ -1,0 +1,67 @@
+import asyncio
+
+class DummyClient:
+    """Simple simulated Binance client for offline testing."""
+
+    def __init__(self, start_balance=1000.0, fee_rate=0.001):
+        # balances stored as {asset: {'free': float, 'locked': float}}
+        self.balances = {"USDT": {"free": float(start_balance), "locked": 0.0}}
+        # trade history list
+        self.trades = []
+        # static prices for a couple of symbols
+        self.prices = {"BTCUSDT": 30000.0, "ETHUSDT": 2000.0}
+        self.fee_rate = fee_rate
+
+    async def get_account(self):
+        return {
+            "balances": [
+                {"asset": a, "free": str(v["free"]), "locked": str(v["locked"])}
+                for a, v in self.balances.items()
+            ]
+        }
+
+    async def get_my_trades(self, symbol):
+        return [t for t in self.trades if t["symbol"] == symbol]
+
+    async def get_avg_price(self, symbol):
+        price = self.prices.get(symbol, 0.0)
+        return {"price": str(price)}
+
+    async def order_market_buy(self, symbol, quantity):
+        price = self.prices.get(symbol, 0.0)
+        cost = price * quantity
+        fee = cost * self.fee_rate
+        if self.balances["USDT"]["free"] < cost + fee:
+            raise RuntimeError("Insufficient USDT balance")
+        self.balances["USDT"]["free"] -= cost + fee
+        base = symbol.replace("USDT", "")
+        self.balances.setdefault(base, {"free": 0.0, "locked": 0.0})
+        self.balances[base]["free"] += quantity
+        self.trades.append({
+            "symbol": symbol,
+            "qty": str(quantity),
+            "price": str(price),
+            "isBuyer": True,
+        })
+        return {"status": "FILLED"}
+
+    async def order_market_sell(self, symbol, quantity):
+        price = self.prices.get(symbol, 0.0)
+        base = symbol.replace("USDT", "")
+        if self.balances.get(base, {"free": 0.0})["free"] < quantity:
+            raise RuntimeError("Insufficient balance")
+        self.balances[base]["free"] -= quantity
+        proceeds = price * quantity
+        fee = proceeds * self.fee_rate
+        self.balances["USDT"]["free"] += proceeds - fee
+        self.trades.append({
+            "symbol": symbol,
+            "qty": str(quantity),
+            "price": str(price),
+            "isBuyer": False,
+        })
+        return {"status": "FILLED"}
+
+    async def close_connection(self):
+        # Nothing to close in the dummy client
+        pass


### PR DESCRIPTION
## Summary
- implement a simple `DummyClient` to simulate Binance with 1000 USDT and fees
- update `get_binance_client` to use `DUMMY_ACCOUNT` and disable testnet usage
- document the new variable in README and `.env.example`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68843df016948329a95882568942c62a