### PR TITLE
Add weight argument to strategies

### DIFF
--- a/strategies/dca.py
+++ b/strategies/dca.py
@@ -10,7 +10,9 @@ from datetime import datetime, timedelta
 # Configure a logger for this module
 logger = logging.getLogger(__name__)
 
-async def execute(client, symbol: str, amount: float, interval_minutes: int):
+async def execute(
+    client, symbol: str, amount: float, interval_minutes: int, weight: float
+):
     """
     Execute DCA strategy.
 
@@ -19,11 +21,16 @@ async def execute(client, symbol: str, amount: float, interval_minutes: int):
         symbol (str): Trading pair, e.g., 'BTCUSDT'.
         amount (float): Amount to invest each time.
         interval_minutes (int): Interval in minutes between purchases.
+        weight (float): Weight of this strategy when executed.
     """
     try:
         # This placeholder logs the intention to buy; implement actual order placement here
         logger.info(
-            "Executing DCA: buying %s units of %s every %s minutes.", amount, symbol, interval_minutes
+            "Executing DCA: buying %s units of %s every %s minutes (weight %.2f).",
+            amount,
+            symbol,
+            interval_minutes,
+            weight,
         )
         # Example call to place a market order (to be implemented):
         # order = await client.order_market_buy(symbol=symbol, quantity=amount)

--- a/strategies/grid.py
+++ b/strategies/grid.py
@@ -15,6 +15,7 @@ async def execute(
     upper_price: float,
     grids: int,
     quantity: float,
+    weight: float,
 ):
     """
     Execute Grid trading strategy.
@@ -26,18 +27,20 @@ async def execute(
         upper_price (float): Upper boundary.
         grids (int): Number of grid levels.
         quantity (float): Quantity to buy or sell at each grid.
+        weight (float): Weight of this strategy when executed.
 
     The strategy should divide the range into intervals and place limit buy orders below
     and limit sell orders above the current price accordingly.
     """
     try:
         logger.info(
-            "Executing Grid strategy for %s: range %.8f-%.8f with %d grids, quantity %f",
+            "Executing Grid strategy for %s: range %.8f-%.8f with %d grids, quantity %f (weight %.2f)",
             symbol,
             lower_price,
             upper_price,
             grids,
             quantity,
+            weight,
         )
         # Implementation placeholder:
         # Compute price levels and place limit orders.

--- a/strategies/scalping.py
+++ b/strategies/scalping.py
@@ -8,7 +8,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-async def execute(client, symbol: str, quantity: float, indicators: dict):
+async def execute(
+    client, symbol: str, quantity: float, indicators: dict, weight: float
+):
     """
     Execute Scalping strategy.
 
@@ -17,15 +19,17 @@ async def execute(client, symbol: str, quantity: float, indicators: dict):
         symbol (str): Trading pair.
         quantity (float): Quantity to trade per signal.
         indicators (dict): Precomputed technical indicators (e.g., moving averages, RSI).
+        weight (float): Weight of this strategy when executed.
 
     This placeholder uses technical indicators to decide whether to enter or exit a trade quickly.
     """
     try:
         logger.info(
-            "Executing Scalping strategy for %s with quantity %f and indicators: %s",
+            "Executing Scalping strategy for %s with quantity %f and indicators: %s (weight %.2f)",
             symbol,
             quantity,
             indicators,
+            weight,
         )
         # Example logic:
         # if indicators.get("short_ma") > indicators.get("long_ma"):

--- a/strategies/sentiment.py
+++ b/strategies/sentiment.py
@@ -14,6 +14,7 @@ async def execute(
     quantity: float,
     sentiment_score: float,
     threshold: float = 0.0,
+    weight: float = 0.0,
     bot=None,
     chat_id=None,
 ):
@@ -29,16 +30,18 @@ async def execute(
         threshold (float): Minimum absolute sentiment value required to trigger a trade.
         bot: Telegram bot instance used to send notifications.
         chat_id: Telegram chat identifier for sending messages.
+        weight (float): Weight of this strategy when executed.
 
     If sentiment_score > threshold, a market buy order is placed; if
     sentiment_score < -threshold, a market sell order is placed.
     """
     try:
         logger.info(
-            "Executing Sentiment strategy for %s with sentiment %.4f and quantity %f",
+            "Executing Sentiment strategy for %s with sentiment %.4f and quantity %f (weight %.2f)",
             symbol,
             sentiment_score,
             quantity,
+            weight,
         )
         if sentiment_score > threshold:
             if bot and chat_id:
@@ -46,7 +49,7 @@ async def execute(
                     chat_id=chat_id,
                     text=(
                         f"Sentiment {sentiment_score:.4f} > {threshold:.4f}. "
-                        f"Buying {quantity} of {symbol}."
+                        f"Buying {quantity} of {symbol} (weight {weight:.2f})."
                     ),
                 )
             order = await client.order_market_buy(symbol=symbol, quantity=quantity)
@@ -57,7 +60,7 @@ async def execute(
                     chat_id=chat_id,
                     text=(
                         f"Sentiment {sentiment_score:.4f} < -{threshold:.4f}. "
-                        f"Selling {quantity} of {symbol}."
+                        f"Selling {quantity} of {symbol} (weight {weight:.2f})."
                     ),
                 )
             order = await client.order_market_sell(symbol=symbol, quantity=quantity)

--- a/strategies/trend_following.py
+++ b/strategies/trend_following.py
@@ -9,7 +9,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-async def execute(client, symbol: str, quantity: float, indicators: dict):
+async def execute(
+    client, symbol: str, quantity: float, indicators: dict, weight: float
+):
     """
     Execute Trend Following strategy.
 
@@ -18,15 +20,17 @@ async def execute(client, symbol: str, quantity: float, indicators: dict):
         symbol (str): Trading pair.
         quantity (float): Quantity to trade.
         indicators (dict): Precomputed trend indicators (e.g., moving average crossover, ADX).
+        weight (float): Weight of this strategy when executed.
 
     Uses trend signals to decide long or short positions.
     """
     try:
         logger.info(
-            "Executing Trend strategy for %s with quantity %f and indicators: %s",
+            "Executing Trend strategy for %s with quantity %f and indicators: %s (weight %.2f)",
             symbol,
             quantity,
             indicators,
+            weight,
         )
         # Example logic:
         # if indicators.get("trend_signal") > 0:

--- a/trading_tasks.py
+++ b/trading_tasks.py
@@ -40,15 +40,16 @@ async def dca_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        amount = (
-            CONFIG["dca_amount"]
-            * CONFIG["weights"]["dca"]
-            * CONFIG.get("risk_level", 1.0)
-        )
+        weight = CONFIG["weights"]["dca"]
+        amount = CONFIG["dca_amount"] * weight * CONFIG.get("risk_level", 1.0)
         interval = CONFIG["dca_interval_minutes"]
         # call the DCA strategy implementation
         await dca.execute(
-            client=None, symbol=symbol, amount=amount, interval_minutes=interval
+            client=None,
+            symbol=symbol,
+            amount=amount,
+            interval_minutes=interval,
+            weight=weight,
         )
         # wait until the next DCA trade
         await asyncio.sleep(interval * 60)
@@ -63,11 +64,8 @@ async def grid_loop():
         lower = CONFIG["grid"]["lower"]
         upper = CONFIG["grid"]["upper"]
         levels = CONFIG["grid"]["levels"]
-        amount = (
-            CONFIG["dca_amount"]
-            * CONFIG["weights"]["grid"]
-            * CONFIG.get("risk_level", 1.0)
-        )
+        weight = CONFIG["weights"]["grid"]
+        amount = CONFIG["dca_amount"] * weight * CONFIG.get("risk_level", 1.0)
         # call the grid strategy implementation
         await grid.execute(
             client=None,
@@ -76,6 +74,7 @@ async def grid_loop():
             upper_price=upper,
             grids=levels,
             quantity=amount,
+            weight=weight,
         )
         await asyncio.sleep(CONFIG["grid_interval_minutes"] * 60)
 
@@ -86,11 +85,8 @@ async def scalping_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = (
-            CONFIG["dca_amount"]
-            * CONFIG["weights"]["scalping"]
-            * CONFIG.get("risk_level", 1.0)
-        )
+        weight = CONFIG["weights"]["scalping"]
+        quantity = CONFIG["dca_amount"] * weight * CONFIG.get("risk_level", 1.0)
         indicators = {"rsi_period": 14, "ema_fast": 7, "ema_slow": 25}
         # call the scalping strategy implementation
         await scalping.execute(
@@ -98,6 +94,7 @@ async def scalping_loop():
             symbol=symbol,
             quantity=quantity,
             indicators=indicators,
+            weight=weight,
         )
         await asyncio.sleep(CONFIG["scalping_interval_seconds"])
 
@@ -108,11 +105,8 @@ async def trend_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = (
-            CONFIG["dca_amount"]
-            * CONFIG["weights"]["trend"]
-            * CONFIG.get("risk_level", 1.0)
-        )
+        weight = CONFIG["weights"]["trend"]
+        quantity = CONFIG["dca_amount"] * weight * CONFIG.get("risk_level", 1.0)
 
         # call the trend following strategy implementation
         await trend_following.execute(
@@ -120,6 +114,7 @@ async def trend_loop():
             symbol=symbol,
             quantity=quantity,
             lookback=100,
+            weight=weight,
         )
         await asyncio.sleep(CONFIG["trend_interval_minutes"] * 60)
 
@@ -130,11 +125,8 @@ async def sentiment_loop():
     """
     while True:
         symbol = CONFIG["symbols"][0]
-        quantity = (
-            CONFIG["dca_amount"]
-            * CONFIG["weights"]["sentiment"]
-            * CONFIG.get("risk_level", 1.0)
-        )
+        weight = CONFIG["weights"]["sentiment"]
+        quantity = CONFIG["dca_amount"] * weight * CONFIG.get("risk_level", 1.0)
         sentiment_score = (
             0.0  # placeholder sentiment score; integrate actual sentiment analysis here
         )
@@ -144,6 +136,7 @@ async def sentiment_loop():
             symbol=symbol,
             sentiment_score=sentiment_score,
             quantity=quantity,
+            weight=weight,
         )
         await asyncio.sleep(CONFIG["sentiment_interval_minutes"] * 60)
 


### PR DESCRIPTION
## Summary
- track current strategy weight in each trading loop
- pass weight to strategy `execute` methods
- log and report the weight in the Sentiment strategy's Telegram messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68844708c374832989a55c1e855b7b17