### PR TITLE
Centralize logging configuration

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import env_loader
+import logger_config
 from datetime import datetime
 
 # Example strategies (to be implemented in strategies package)
@@ -11,11 +12,7 @@ from strategies import dca, grid, scalping, trend_following, sentiment
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
+# Configure module logger
 logger = logging.getLogger(__name__)
 
 # Bot configuration

--- a/logger_config.py
+++ b/logger_config.py
@@ -1,0 +1,9 @@
+"""Global logging configuration."""
+
+import logging
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -2,6 +2,7 @@ import os
 import env_loader
 import asyncio
 import logging
+import logger_config
 
 from trading_tasks import (
     dca_loop,
@@ -14,9 +15,7 @@ from trading_tasks import (
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 import binance_client
 
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
-)
+# Configure module logger
 logger = logging.getLogger(__name__)
 
 

--- a/trading_tasks.py
+++ b/trading_tasks.py
@@ -1,12 +1,10 @@
 import asyncio
 import logging
+import logger_config
 
 from strategies import dca, grid, scalping, trend_following, sentiment
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
-)
+# Configure module logger
 logger = logging.getLogger(__name__)
 
 # Bot configuration


### PR DESCRIPTION
## Summary
- add a new `logger_config.py` with common `logging.basicConfig`
- use `logger_config` module in `trading_tasks.py`, `bot.py`, and `telegram_bot.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68844895609c8329bd456a4d0e56726c