### PR TITLE
Enable Telegram alerts for scalping strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 
 # Telegram bot token from BotFather
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
+# Chat ID where the bot should send status updates
+TELEGRAM_CHAT_ID=your_telegram_chat_id_here
 
 # Binance API keys for live or testnet trading
 BINANCE_API_KEY=your_binance_api_key_here

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Trading bot for Binance integrated with Telegram, focusing on informative and in
 ## Setup
 
 1. Copy `.env.example` to `.env`.
-2. Edit `.env` and provide your Telegram bot token. If you want to trade on
-   Binance, fill in your API keys. To run the bot without real API access,
-   set `DUMMY_ACCOUNT=true` and the bot will simulate a balance starting at
-   1000 USDT.
+2. Edit `.env` and provide your Telegram bot token and the chat ID where the bot
+   should send updates. If you want to trade on Binance, fill in your API keys.
+   To run the bot without real API access, set `DUMMY_ACCOUNT=true` and the bot
+   will simulate a balance starting at 1000 USDT.
 
 The bot loads this file automatically on startup so your environment variables are available.
 

--- a/strategies/scalping.py
+++ b/strategies/scalping.py
@@ -9,7 +9,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 async def execute(
-    client, symbol: str, quantity: float, indicators: dict, weight: float
+    client,
+    symbol: str,
+    quantity: float,
+    indicators: dict,
+    weight: float,
+    bot=None,
+    chat_id=None,
 ):
     """
     Execute Scalping strategy.
@@ -24,13 +30,13 @@ async def execute(
     This placeholder uses technical indicators to decide whether to enter or exit a trade quickly.
     """
     try:
-        logger.info(
-            "Executing Scalping strategy for %s with quantity %f and indicators: %s (weight %.2f)",
-            symbol,
-            quantity,
-            indicators,
-            weight,
+        message = (
+            "Executing Scalping strategy for %s with quantity %f and indicators: %s (weight %.2f)"
+            % (symbol, quantity, indicators, weight)
         )
+        logger.info(message)
+        if bot and chat_id:
+            await bot.send_message(chat_id=chat_id, text=message)
         # Example logic:
         # if indicators.get("short_ma") > indicators.get("long_ma"):
         #     # Bullish signal: place market buy order

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -12,6 +12,7 @@ from trading_tasks import (
     sentiment_loop,
     CONFIG,
 )
+import trading_tasks
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 import binance_client
 
@@ -20,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 async def start_command(update, context):
+    trading_tasks.TELEGRAM_CHAT_ID = update.effective_chat.id
+    trading_tasks.TELEGRAM_BOT = context.bot
     await update.message.reply_text(
         "Hello! I'm your Binance trading bot.\n"
         "I run various trading strategies and update you on Telegram.\n"
@@ -174,6 +177,11 @@ def main() -> None:
         )
 
     application = ApplicationBuilder().token(telegram_token).build()
+    trading_tasks.TELEGRAM_BOT = application.bot
+    # Use chat ID from environment until /start command provides one
+    trading_tasks.TELEGRAM_CHAT_ID = trading_tasks.TELEGRAM_CHAT_ID or os.getenv(
+        "TELEGRAM_CHAT_ID"
+    )
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("status", status_command))
     application.add_handler(CommandHandler("help", help_command))

--- a/trading_tasks.py
+++ b/trading_tasks.py
@@ -1,11 +1,16 @@
 import asyncio
 import logging
+import os
 import logger_config
 
 from strategies import dca, grid, scalping, trend_following, sentiment
 
 # Configure module logger
 logger = logging.getLogger(__name__)
+
+# Telegram integration
+TELEGRAM_BOT = None
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
 
 # Bot configuration
 CONFIG = {
@@ -93,6 +98,8 @@ async def scalping_loop():
             quantity=quantity,
             indicators=indicators,
             weight=weight,
+            bot=TELEGRAM_BOT,
+            chat_id=TELEGRAM_CHAT_ID,
         )
         await asyncio.sleep(CONFIG["scalping_interval_seconds"])
 
@@ -135,6 +142,8 @@ async def sentiment_loop():
             sentiment_score=sentiment_score,
             quantity=quantity,
             weight=weight,
+            bot=TELEGRAM_BOT,
+            chat_id=TELEGRAM_CHAT_ID,
         )
         await asyncio.sleep(CONFIG["sentiment_interval_minutes"] * 60)
 


### PR DESCRIPTION
## Summary
- notify Telegram when running the scalping strategy
- pass Telegram bot details into strategy loops
- store chat ID at `/start` and allow configuration via env var
- document new `TELEGRAM_CHAT_ID` variable

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68844c1516688329bb3796af902dccd1