### PR TITLE
Fix trend strategy call and enable Telegram notifications

### DIFF
--- a/strategies/trend_following.py
+++ b/strategies/trend_following.py
@@ -10,7 +10,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 async def execute(
-    client, symbol: str, quantity: float, indicators: dict, weight: float
+    client,
+    symbol: str,
+    quantity: float,
+    indicators: dict,
+    weight: float,
+    bot=None,
+    chat_id=None,
 ):
     """
     Execute Trend Following strategy.
@@ -25,13 +31,13 @@ async def execute(
     Uses trend signals to decide long or short positions.
     """
     try:
-        logger.info(
-            "Executing Trend strategy for %s with quantity %f and indicators: %s (weight %.2f)",
-            symbol,
-            quantity,
-            indicators,
-            weight,
+        message = (
+            "Executing Trend strategy for %s with quantity %f and indicators: %s (weight %.2f)"
+            % (symbol, quantity, indicators, weight)
         )
+        logger.info(message)
+        if bot and chat_id:
+            await bot.send_message(chat_id=chat_id, text=message)
         # Example logic:
         # if indicators.get("trend_signal") > 0:
         #     # Positive trend: go long

--- a/trading_tasks.py
+++ b/trading_tasks.py
@@ -114,12 +114,15 @@ async def trend_loop():
         quantity = CONFIG["dca_amount"] * weight * CONFIG.get("risk_level", 1.0)
 
         # call the trend following strategy implementation
+        indicators = {"lookback": 100}
         await trend_following.execute(
             client=None,
             symbol=symbol,
             quantity=quantity,
-            lookback=100,
+            indicators=indicators,
             weight=weight,
+            bot=TELEGRAM_BOT,
+            chat_id=TELEGRAM_CHAT_ID,
         )
         await asyncio.sleep(CONFIG["trend_interval_minutes"] * 60)
 


### PR DESCRIPTION
## Summary
- update trend strategy to send messages to Telegram
- fix `trend_loop` to pass indicator dictionary

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688451c7e6d48329a5e63fcabc0a1dc4