### PR TITLE
Implement auto weight training

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ The bot loads this file automatically on startup so your environment variables a
 
 You can control how much capital each strategy uses by setting weights from Telegram. The weights of all strategies must sum to `1`.
 
-Use `/weights` to view the current weights and `/setweights <dca> <grid> <scalping> <trend> <sentiment>` to update them. For example:
+Use `/weights` to view the current weights and `/setweights <dca> <grid> <scalping> <trend> <sentiment>` to update them.
+You can also run `/setweights auto` to calculate weights from recent market data.
+For example:
 
 ```
 /setweights 0.2 0.2 0.2 0.2 0.2

--- a/data_training.py
+++ b/data_training.py
@@ -1,0 +1,63 @@
+import logging
+import pandas as pd
+from binance import AsyncClient
+
+import binance_client
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_historical_data(symbol: str, interval: str, lookback: str):
+    """Download historical klines from Binance and return as DataFrame."""
+    client = await binance_client.get_binance_client()
+    try:
+        klines = await client.get_historical_klines(symbol, interval, lookback)
+    finally:
+        await client.close_connection()
+
+    df = pd.DataFrame(
+        klines,
+        columns=[
+            "open_time",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "close_time",
+            "quote_asset_volume",
+            "number_of_trades",
+            "taker_buy_base",
+            "taker_buy_quote",
+            "ignore",
+        ],
+    )
+    df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
+    df["close_time"] = pd.to_datetime(df["close_time"], unit="ms")
+    for col in ["open", "high", "low", "close", "volume"]:
+        df[col] = df[col].astype(float)
+    return df
+
+
+async def calculate_recommended_weights(
+    symbol: str,
+    interval: str = AsyncClient.KLINE_INTERVAL_1HOUR,
+    lookback: str = "30 days ago UTC",
+) -> dict:
+    """Return recommended strategy weights based on simple performance metrics."""
+    df = await fetch_historical_data(symbol, interval, lookback)
+    returns = df["close"].pct_change().dropna()
+    momentum = returns.mean()
+    volatility = returns.std()
+
+    metrics = {
+        "dca": max(momentum, 0.0) + 1e-9,
+        "grid": volatility + 1e-9,
+        "scalping": volatility / 2 + 1e-9,
+        "trend": abs(momentum) + 1e-9,
+        "sentiment": 1e-9,  # placeholder metric
+    }
+    total = sum(metrics.values())
+    weights = {k: v / total for k, v in metrics.items()}
+    logger.info("Recommended weights calculated: %s", weights)
+    return weights


### PR DESCRIPTION
## Summary
- add new `data_training` module for historical data download
- compute simple metrics to recommend strategy weights
- allow `/setweights auto` to retrain weights
- schedule periodic weight training

## Testing
- `python -m py_compile data_training.py telegram_bot.py trading_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68845ded38608329b65b088e98bdb67d