### PR TITLE
Extend lookback for weight training

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You can control how much capital each strategy uses by setting weights from Tele
 
 Use `/weights` to view the current weights and `/setweights <dca> <grid> <scalping> <trend> <sentiment>` to update them.
 You can also run `/setweights auto` to calculate weights from recent market data.
+The automatic calculation downloads roughly one year of hourly price history to
+determine momentum and volatility.
 For example:
 
 ```

--- a/data_training.py
+++ b/data_training.py
@@ -42,7 +42,7 @@ async def fetch_historical_data(symbol: str, interval: str, lookback: str):
 async def calculate_recommended_weights(
     symbol: str,
     interval: str = AsyncClient.KLINE_INTERVAL_1HOUR,
-    lookback: str = "30 days ago UTC",
+    lookback: str = "365 days ago UTC",
 ) -> dict:
     """Return recommended strategy weights based on simple performance metrics."""
     df = await fetch_historical_data(symbol, interval, lookback)
@@ -66,7 +66,7 @@ async def calculate_recommended_weights(
 async def calculate_recommended_weights_with_progress(
     symbol: str,
     interval: str = AsyncClient.KLINE_INTERVAL_1HOUR,
-    lookback: str = "30 days ago UTC",
+    lookback: str = "365 days ago UTC",
     bot=None,
     chat_id=None,
 ) -> dict:

--- a/dummy_client.py
+++ b/dummy_client.py
@@ -32,11 +32,11 @@ class DummyClient:
         from datetime import datetime, timedelta
         import random
 
-        # very rough parsing of lookback like "30 days ago UTC"
+        # very rough parsing of lookback like "365 days ago UTC"
         try:
             days = int(str(lookback).split()[0])
         except Exception:
-            days = 30
+            days = 365
 
         # assume hourly interval regardless of the value passed
         points = days * 24


### PR DESCRIPTION
## Summary
- download a year of market data when calculating strategy weights
- clarify lookback period in the README
- adjust dummy client lookback parsing

## Testing
- `python -m compileall -q .`
- `pip install -r requirements.txt`
- `python - <<'PY'
from dummy_client import DummyClient
import asyncio
from strategies import dca, grid, scalping, trend_following, sentiment

client = DummyClient(start_balance=100000)

async def test():
    await dca.execute(client, 'BTCUSDT', 1.0, 60, 0.5)
    await grid.execute(client, 'BTCUSDT', 10000, 20000, 5, 0.1, 0.2)
    await scalping.execute(client, 'BTCUSDT', 0.1, {'rsi': 50}, 0.1)
    await trend_following.execute(client, 'BTCUSDT', 0.1, {'lookback':100}, 0.1)
    await sentiment.execute(client, 'BTCUSDT', 0.1, 0.5, weight=0.1)

asyncio.run(test())
print('strategies executed')
PY

------
https://chatgpt.com/codex/tasks/task_e_68846463250883299c9e28a492bf3812